### PR TITLE
Collection fixes

### DIFF
--- a/FishNet/Plugins/FishySteamworks/Core/BidirectionalDictionary.cs
+++ b/FishNet/Plugins/FishySteamworks/Core/BidirectionalDictionary.cs
@@ -5,8 +5,8 @@ namespace FishySteamworks
 {
     public class BidirectionalDictionary<T1, T2> : IEnumerable
     {
-        private Dictionary<T1, T2> t1ToT2Dict = new Dictionary<T1, T2>();
-        private Dictionary<T2, T1> t2ToT1Dict = new Dictionary<T2, T1>();
+        private readonly Dictionary<T1, T2> t1ToT2Dict = new Dictionary<T1, T2>();
+        private readonly Dictionary<T2, T1> t2ToT1Dict = new Dictionary<T2, T1>();
 
         public IEnumerable<T1> FirstTypes => t1ToT2Dict.Keys;
         public IEnumerable<T2> SecondTypes => t2ToT1Dict.Keys;
@@ -32,6 +32,12 @@ namespace FishySteamworks
 
             t2ToT1Dict[key] = value;
             t1ToT2Dict[value] = key;
+        }
+
+        public void Clear()
+        {
+            t1ToT2Dict.Clear();
+            t2ToT1Dict.Clear();
         }
 
         public T2 Get(T1 key) => t1ToT2Dict[key];

--- a/FishNet/Plugins/FishySteamworks/Core/BidirectionalDictionary.cs
+++ b/FishNet/Plugins/FishySteamworks/Core/BidirectionalDictionary.cs
@@ -20,10 +20,7 @@ namespace FishySteamworks
 
         public void Add(T1 key, T2 value)
         {
-            if (t1ToT2Dict.ContainsKey(key))
-            {
-                Remove(key);
-            }
+            Remove(key);
 
             t1ToT2Dict[key] = value;
             t2ToT1Dict[value] = key;
@@ -31,10 +28,7 @@ namespace FishySteamworks
 
         public void Add(T2 key, T1 value)
         {
-            if (t2ToT1Dict.ContainsKey(key))
-            {
-                Remove(key);
-            }
+            Remove(key);
 
             t2ToT1Dict[key] = value;
             t1ToT2Dict[value] = key;
@@ -54,20 +48,16 @@ namespace FishySteamworks
 
         public void Remove(T1 key)
         {
-            if (Contains(key))
+            if (t1ToT2Dict.Remove(key, out T2 val))
             {
-                T2 val = t1ToT2Dict[key];
-                t1ToT2Dict.Remove(key);
                 t2ToT1Dict.Remove(val);
             }
         }
         public void Remove(T2 key)
         {
-            if (Contains(key))
+            if (t2ToT1Dict.Remove(key, out T1 val))
             {
-                T1 val = t2ToT1Dict[key];
                 t1ToT2Dict.Remove(val);
-                t2ToT1Dict.Remove(key);
             }
         }
 

--- a/FishNet/Plugins/FishySteamworks/Core/ServerSocket.cs
+++ b/FishNet/Plugins/FishySteamworks/Core/ServerSocket.cs
@@ -101,6 +101,8 @@ namespace FishySteamworks.Server
                 base.PeerToPeer = peerToPeer;
                 SetMaximumClients(maximumClients);
                 _nextConnectionId = 0;
+                _steamConnections.Clear();
+                _steamIds.Clear();
                 _cachedConnectionIds.Clear();
 
                 base.SetLocalConnectionState(LocalConnectionState.Starting, true);


### PR DESCRIPTION
This change requires .net 9.0 which is supported in unity `2021.2` (https://docs.unity3d.com/2021.2/Documentation/Manual/CSharpCompiler.html) and up. Alternatively the `Remove()` code could use `TryGetValue()` instead of the double lookup with `Contains()` and then the index operator.

The main fix is to `ServerSocket.cs` which previously retained old connections which could cause bugs when stopping and starting connections.