### PR TITLE
Clear out steam connections and steam ids on connect

### DIFF
--- a/FishNet/Plugins/FishySteamworks/Core/ServerSocket.cs
+++ b/FishNet/Plugins/FishySteamworks/Core/ServerSocket.cs
@@ -141,6 +141,8 @@ namespace FishySteamworks.Server
                 base.PeerToPeer = peerToPeer;
                 SetMaximumClients(maximumClients);
                 _nextConnectionId = 0;
+                _steamConnections.Clear();
+                _steamIds.Clear();
                 _cachedConnectionIds.Clear();
                 _iteratingConnections = false;
 


### PR DESCRIPTION
This fix was part of a previous PR but was removed when overwriting the PR with a different implementation

https://github.com/FirstGearGames/FishySteamworks/pull/13/files#diff-794714384a98a6c68abd11af3cb29560daeb1db70f05ca5eb673d58b056ebf37R104-R107